### PR TITLE
Ian

### DIFF
--- a/README.org
+++ b/README.org
@@ -36,6 +36,13 @@ calling:
 
 : M-x org-weather-refresh
 
+** openweather API Key.
+The [[http://openweathermap.org/api][openweather]]  site now requires you to sign up for an API key. You
+can choose a free key or various paid options. You need to add the API
+key to your .emacs:
+
+: (setq org-weather-api-key  "YourAPIKey")
+
 * Data License
 
 According to http://openweathermap.org/price:

--- a/org-weather.el
+++ b/org-weather.el
@@ -39,11 +39,14 @@
 (defvar org-weather-location "Graz,AT")
 
 ;; Define the format string to display in the agenda, see below for available wildcards
-;; Data is licensed under cc by-sa, so we must display the "OpenWeatherMap" name
-(defvar org-weather-format "OpenWeatherMap: %desc, %tmin-%tmax%tu, %p%pu, %h%hu, %s%su")
+(defvar org-weather-format "Weather: %desc, %tmin-%tmax%tu, %p%pu, %h%hu, %s%su")
+
+;; Your openweather API key.
+(defvar org-weather-api-key  "")
 
 ;; The api url, no need to change ususally
-(defvar org-weather-api-url "http://api.openweathermap.org/data/2.5/forecast/daily?q=%s&mode=json&units=metric&cnt=7")
+(defvar org-weather-api-url "http://api.openweathermap.org/data/2.5/forecast/daily?q=%s&mode=json&units=metric&cnt=7&&APPID=%s")
+
 (defvar org-weather-api-timeout 2)
 
 ;; The units, just for displaying
@@ -62,7 +65,7 @@
   (with-timeout (org-weather-api-timeout)
       (with-temp-buffer
         (url-insert-file-contents
-         (format org-weather-api-url org-weather-location))
+        (format org-weather-api-url org-weather-location org-weather-api-key))
         (json-read))))
 
 (defun org-weather-add-to-cache (item)


### PR DESCRIPTION
Openweather now requires users to us an API key to request forecasts. These commits add a new variable for your API Key, which can be set in your .emacs.